### PR TITLE
Fix46 fixing efoldmine incorrect result deposition

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -423,9 +423,9 @@ rule all:
             resrange = df_exploded['trimmed'],
             uniprot_ac = df_exploded['uniprot_ac'].str.upper()),
 
-	expand("{hugo_name}/efoldmine/{uniprot_ac}.tabular",
+        expand("{hugo_name}/efoldmine/{uniprot_ac}.tabular",
             zip,
-	        hugo_name=df['protein'].str.upper(),
+            hugo_name=df['protein'].str.upper(),
             uniprot_ac=df['uniprot_ac'].str.upper())
 
 


### PR DESCRIPTION
This PR addresses Issue #46 where for an input batch all resulting file of the efoldmine module were being saved in all protein folders causing issues with downstream importing. 

The fix was to add 'zip' to efoldmine rule under `rule all:` 
