### PR TITLE
Fix #48 #57 fixing cancermuts_data final path to lowercase+pancancer_clinvar_saturation

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -993,24 +993,18 @@ rule mutlist:
         t_obj = time.strptime(s_ti)
         date=time.strftime("%d%m%Y", t_obj)
         
-        if not os.path.exists(mutlist_clinvar) and\
-            not os.path.exists(external_mutlist):
-            cancermode="pancancer"
-
         if os.path.exists(mutlist_clinvar) and\
             os.path.exists(external_mutlist):
             cancermode="pancancer_clinvar_others"
 
-        if os.path.exists(mutlist_clinvar) and\
-            not os.path.exists(external_mutlist):
-            cancermode="pancancer_clinvar_saturation"
-
         if not os.path.exists(mutlist_clinvar) and\
             os.path.exists(external_mutlist):
             cancermode="pancancer_others"
+        
+        if not os.path.exists(external_mutlist):
+            cancermode="pancancer_clinvar_saturation"
 
-
-        final_path = f"{path}/{research_field}/{wildcards.hugo_name}/"\
+        final_path = f"{path}/{research_field}/{wildcards.hugo_name.lower()}/"\
                         f"{cancermode}/{date}"
 
         shell("mkdir -p {final_path} &&"\


### PR DESCRIPTION
Addresses issues: #48 + #57 
Changes to rules: cancermuts and mutlist. 

The changes ensure that unless an external mutlist is used, irrespective of whether ClinVar variants were found for the given protein the cancermuts_data path contains `pancancer_clinvar_saturation` and removes the incidences of `pancancer`. 

Additionally, the changes ensure the final protein folder name is lowercase to streamline the importing process. 