### PR TITLE
Updated dssp and mentha version

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,8 +93,8 @@ input:
 modules:
     interactome:
         mentha2pdb:
-            database_date: 2024-03-04
-            database_path: /data/databases/mentha-20240304
+            database_date: 2025-04-28
+            database_path: /data/databases/mentha-20250428
             AF_Huri_path:  /data/databases/AF_Huri_HuMAP/summary/HuRI.csv
             AF_HuMAP_path: /data/databases/AF_Huri_HuMAP/summary/humap.csv
             AF_Huri_HuMAP_path: /data/databases/AF_Huri_HuMAP
@@ -102,7 +102,7 @@ modules:
             database_path: /data/databases/hpc_atlas/HPC-Atlas_gene.txt
     structure_selection:
         alphafold:
-            dssp_exec: /usr/local/dssp-3.0.10/bin/mkdssp
+            dssp_exec: /usr/local/dssp-4.4/bin/mkdssp
         pdbminer:
             pdbminer_env: . /usr/local/envs/PDBminer/bin/activate
         procheck:
@@ -265,7 +265,7 @@ BLM
 │   │   ├── HPC-Atlas_gene.txt → /data/databases/hpc_atlas/HPC-Atlas_gene.txt
 │   │   └── readme.txt
 │   └── mentha2pdb
-│       ├── 2023-04-17 → /data/databases/mentha-20230417/2023-04-17
+│       ├── 2025-04-28 → /data/databases/mentha-20250428/2025-04-28
 │       ├── P54132.csv
 │       ├── inputs_afmulti
 │       │   └── BLM

--- a/config.yaml
+++ b/config.yaml
@@ -3,8 +3,8 @@ input:
 modules:
     interactome:
         mentha2pdb:
-            database_date: 2024-03-04
-            database_path: /data/databases/mentha-20240304
+            database_date: 2025-04-28
+            database_path: /data/databases/mentha-20250428
             AF_Huri_path:  /data/databases/AF_Huri_HuMAP/summary/HuRI.csv
             AF_HuMAP_path: /data/databases/AF_Huri_HuMAP/summary/humap.csv
             AF_Huri_HuMAP_path: /data/databases/AF_Huri_HuMAP
@@ -12,7 +12,7 @@ modules:
             database_path: /data/databases/hpc_atlas/HPC-Atlas_gene.txt
     structure_selection:
         alphafold:
-            dssp_exec: /usr/local/dssp-3.0.10/bin/mkdssp
+            dssp_exec: /usr/local/dssp-4.4/bin/mkdssp
         pdbminer:
             pdbminer_env: . /usr/local/envs/PDBminer/bin/activate
         procheck:


### PR DESCRIPTION
In this PR:

- Configuration file was updated to:
    - Point to the new DSSP 4.4 binary.
    - Point to the 2025 Mentha version 

- README.md  was adjusted accordingly