### PR TITLE
fixed foldx version string

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -144,8 +144,8 @@ def fetch_foldx_version(modules, df, gene):
         m = re.search(r"FoldX[^0-9]*([0-9]+(?:\.[0-9]+)?)", lines[2])
         if not m:
             raise ValueError(f"Unexpected FoldX log format for file {log_path}")
-        version = m.group(1)
-        if version not in {"5", "5.1"}:
+        version = "foldx"+ m.group(1)
+        if version not in {"foldx5", "foldx5.1"}:
             raise ValueError(f"Unexpected FoldX version in {log_path}: {version}")
         versions.add(version)
         if len(versions) > 1:

--- a/example/essentials/CRX/metadata/metadata.yaml
+++ b/example/essentials/CRX/metadata/metadata.yaml
@@ -17,4 +17,4 @@ review_status: 0
 structure_source: AFDB
 linker_design: false
 pdb_id: ''
-stability_foldx_version: '5'
+stability_foldx_version: foldx5

--- a/example/essentials/CRX/simple_mode/metadata.yaml
+++ b/example/essentials/CRX/simple_mode/metadata.yaml
@@ -17,4 +17,4 @@ review_status: 0
 structure_source: AFDB
 linker_design: false
 pdb_id: ''
-stability_foldx_version: '5'
+stability_foldx_version: foldx5

--- a/example/essentials/SUMO3/metadata/metadata.yaml
+++ b/example/essentials/SUMO3/metadata/metadata.yaml
@@ -17,4 +17,4 @@ review_status: 0
 structure_source: PDB
 linker_design: false
 pdb_id: SUMO3_12-90.pdb
-stability_foldx_version: '5'
+stability_foldx_version: foldx5

--- a/example/essentials/SUMO3/simple_mode/metadata.yaml
+++ b/example/essentials/SUMO3/simple_mode/metadata.yaml
@@ -17,4 +17,4 @@ review_status: 0
 structure_source: PDB
 linker_design: false
 pdb_id: SUMO3_12-90.pdb
-stability_foldx_version: '5'
+stability_foldx_version: foldx5

--- a/example/essentials/Snakefile
+++ b/example/essentials/Snakefile
@@ -144,8 +144,8 @@ def fetch_foldx_version(modules, df, gene):
         m = re.search(r"FoldX[^0-9]*([0-9]+(?:\.[0-9]+)?)", lines[2])
         if not m:
             raise ValueError(f"Unexpected FoldX log format for file {log_path}")
-        version = m.group(1)
-        if version not in {"5", "5.1"}:
+        version = "foldx"+ m.group(1)
+        if version not in {"foldx5", "foldx5.1"}:
             raise ValueError(f"Unexpected FoldX version in {log_path}: {version}")
         versions.add(version)
         if len(versions) > 1:

--- a/example/idps/Snakefile
+++ b/example/idps/Snakefile
@@ -144,8 +144,8 @@ def fetch_foldx_version(modules, df, gene):
         m = re.search(r"FoldX[^0-9]*([0-9]+(?:\.[0-9]+)?)", lines[2])
         if not m:
             raise ValueError(f"Unexpected FoldX log format for file {log_path}")
-        version = m.group(1)
-        if version not in {"5", "5.1"}:
+        version = "foldx"+ m.group(1)
+        if version not in {"foldx5", "foldx5.1"}:
             raise ValueError(f"Unexpected FoldX version in {log_path}: {version}")
         versions.add(version)
         if len(versions) > 1:

--- a/example/standard/CRX/metadata/metadata.yaml
+++ b/example/standard/CRX/metadata/metadata.yaml
@@ -17,4 +17,4 @@ review_status: 0
 structure_source: AFDB
 linker_design: false
 pdb_id: ''
-stability_foldx_version: '5'
+stability_foldx_version: foldx5

--- a/example/standard/CRX/simple_mode/metadata.yaml
+++ b/example/standard/CRX/simple_mode/metadata.yaml
@@ -17,4 +17,4 @@ review_status: 0
 structure_source: AFDB
 linker_design: false
 pdb_id: ''
-stability_foldx_version: '5'
+stability_foldx_version: foldx5

--- a/example/standard/SUMO3/metadata/metadata.yaml
+++ b/example/standard/SUMO3/metadata/metadata.yaml
@@ -17,4 +17,4 @@ review_status: 0
 structure_source: PDB
 linker_design: false
 pdb_id: SUMO3_12-90.pdb
-stability_foldx_version: '5'
+stability_foldx_version: foldx5

--- a/example/standard/SUMO3/simple_mode/metadata.yaml
+++ b/example/standard/SUMO3/simple_mode/metadata.yaml
@@ -17,4 +17,4 @@ review_status: 0
 structure_source: PDB
 linker_design: false
 pdb_id: SUMO3_12-90.pdb
-stability_foldx_version: '5'
+stability_foldx_version: foldx5

--- a/example/standard/Snakefile
+++ b/example/standard/Snakefile
@@ -144,8 +144,8 @@ def fetch_foldx_version(modules, df, gene):
         m = re.search(r"FoldX[^0-9]*([0-9]+(?:\.[0-9]+)?)", lines[2])
         if not m:
             raise ValueError(f"Unexpected FoldX log format for file {log_path}")
-        version = m.group(1)
-        if version not in {"5", "5.1"}:
+        version = "foldx"+ m.group(1)
+        if version not in {"foldx5", "foldx5.1"}:
             raise ValueError(f"Unexpected FoldX version in {log_path}: {version}")
         versions.add(version)
         if len(versions) > 1:


### PR DESCRIPTION
Now, the foldx version appears in metadata as 1 of the following:
- foldx5
- foldx5.1
- null (if the stability calculations don't exist)